### PR TITLE
#48 Added "mi" unit and bolded active text

### DIFF
--- a/frontend/src/components/panels/project_filters_panel/filter_map_components/ProximitySlider.js
+++ b/frontend/src/components/panels/project_filters_panel/filter_map_components/ProximitySlider.js
@@ -34,8 +34,8 @@ class ProximitySlider extends React.Component {
 	constructor(props) {
 		super(props);
 		this.state = {
-			minValue: 5,
-			maxValue: 50,
+			minValue: 1,
+			maxValue: 20,
             steps: 5
 		}
 	}
@@ -48,7 +48,7 @@ class ProximitySlider extends React.Component {
 	    }
 	  }
 	  return miLabels.reduce(function(result, year) {
-	    result[year] = year.toString();
+	    result[year] = year.toString().concat('mi');
 	    return result;
 	  }, {});
 	}
@@ -61,7 +61,7 @@ class ProximitySlider extends React.Component {
 	render() {
 		return (
 			<div>
-				<Slider 
+				<Slider
 					min={this.state.minValue}
 					max={this.state.maxValue}
 					step={this.state.steps}

--- a/frontend/src/styles/panels/_filters_panel.scss
+++ b/frontend/src/styles/panels/_filters_panel.scss
@@ -73,4 +73,12 @@
         border: solid 2px #509646;
         background-color: #509646;
     }
+
+  .rc-slider-mark-text-active {
+      font-weight: bolder;
+  }
+
+  .rc-slider-mark-text {
+      font-style: italic;
+  }
 }


### PR DESCRIPTION
Changed styling of proximity slider so it includes "mi" unit and bolded active text.
Lower bounds of the active text are also bolded instead of strictly the upper bound.